### PR TITLE
parseOBDResponse not treating reserved literal

### DIFF
--- a/device.go
+++ b/device.go
@@ -459,6 +459,10 @@ func parseOBDResponse(cmd OBDCommand, outputs []string) (*Result, error) {
 			"No data from car, time out from elm device?",
 		)
 	}
+	if payload == "SEARCHING..." && len(outputs) >= 2 {
+                fmt.Println("Ignoring reserved literal \"SEARCHING...\", considering next one.")
+                payload = outputs[1]
+	}
 
 	return NewResult(payload)
 }


### PR DESCRIPTION
While trying a cheap chinese ELM327 cable, I got: "Failed to get rpm Expected at least 3 OBD literals: SEARCHING..."

This is happens because **parseOBDResponse** on **device.go** is receiving 2 arguments, the first is "SEARCHING..." and the other are the OBD literals. So, when it calls **NewResult(payload),** it passes only the first argument wich, in this case, is "SEARCHING...". 

This is the call sequence I got while testing in a car:

**runs command to get engine RPM**

- <rawdevice.go>:processResult:
    `dev.outputs =  [ELM327 v1.5]`

- <rawdevice.go>:processResult:
    `dev.outputs =  [OK]`

- <rawdevice.go>:processResult:
    `dev.outputs =  [SEARCHING... 41 0C 0B F4]`

- <device.go>:RunOBDCommand:
    `outputs len =  2`
    `outputs content =  [SEARCHING... 41 0C 0B F4]`

- <device.go>:NewResult:
    ` Failed to get rpm Expected at least 3 OBD literals: SEARCHING...`