### PR TITLE
retry attempts on "UNABLE TO CONNECT"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.1] - 2020-03-03
+### Fixed 
+- Some slow obd-ii interfaces seems to timeout with a "UNABLE TO CONNECT" answer. Retrying after 5 seconds seems to fix the problem
+
 ## [0.6.0] - 2019-03-20
 
 ### Fixed 


### PR DESCRIPTION
# Description

With my obd-ii adapter (this one https://www.amazon.ca/Revesun-ELM327-Engine-MODELS-DIAGNOSTIC/dp/B00R285RU6) I get the error "UNABLE TO CONNECT" if I re-try after in succeeding one. If I wait 5 seconds, it works.

This PR does an auto-retry.

# Checklist

- [ x] Running `go test` locally is successful
- [ ] **VERSION** has been changed
- [ ] Changes has been documented in **CHANGELOG.md**
