### PR TITLE
Support for network connected devices

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -106,5 +106,5 @@ func TestService01Command(t *testing.T) {
 
 func TestService04Command(t *testing.T) {
 	command := NewClearTroubleCodes()
-	assert(t, command.ModeID() == SERVICE_04_ID, "Service id is not "+string(SERVICE_04_ID))
+	assert(t, command.ModeID() == SERVICE_04_ID, fmt.Sprintf("Service id is not %d", SERVICE_04_ID))
 }

--- a/device.go
+++ b/device.go
@@ -211,8 +211,8 @@ func NewDevice(addr string, debug bool) (*Device, error) {
 	switch u.Scheme {
 	case "serial":
 		dev.rawDevice, err = NewSerialDevice(u)
-	case "tcp":
-		dev.rawDevice, err = NewTCPDevice(u)
+	case "tcp", "tcp4", "tcp6", "unix":
+		dev.rawDevice, err = NewNetDevice(u)
 	case "test":
 		dev.rawDevice, err = &MockDevice{}, nil
 	}

--- a/device.go
+++ b/device.go
@@ -276,6 +276,29 @@ func (dev *Device) GetVersion() (string, error) {
 	return strings.Trim(version, " "), nil
 }
 
+// GetVoltage gets the current battery voltage of the vehicle as measured
+// by the ELM327 device.
+func (dev *Device) GetVoltage() (float32, error) {
+	rawRes := dev.rawDevice.RunCommand("AT RV")
+
+	if rawRes.Failed() {
+		return -1, rawRes.GetError()
+	}
+
+	if dev.outputDebug {
+		fmt.Println(rawRes.FormatOverview())
+	}
+
+	output := rawRes.GetOutputs()[0]
+	voltage, err := strconv.ParseFloat(output[:len(output)-1], 32)
+
+	if err != nil {
+		return -1, fmt.Errorf("voltage is not a floating point number: %w", err)
+	}
+
+	return float32(voltage), nil
+}
+
 // CheckSupportedCommands check which commands are supported by the car connected
 // to the ELM327 device.
 func (dev *Device) CheckSupportedCommands() (*SupportedCommands, error) {

--- a/device.go
+++ b/device.go
@@ -2,6 +2,8 @@ package elmobd
 
 import (
 	"fmt"
+	"net/url"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -193,27 +195,37 @@ type Device struct {
 
 // NewDevice constructs a Device by initilizing the serial connection and
 // setting the protocol to talk with the car to "automatic".
-func NewDevice(devicePath string, debug bool) (*Device, error) {
-	rawDev, err := NewRealDevice(devicePath)
+func NewDevice(addr string, debug bool) (*Device, error) {
+	// If addr is an existing file/device we use it as a serial device
+	if _, err := os.Stat(addr); err == nil {
+		addr = fmt.Sprintf("serial://%s", addr)
+	}
+
+	u, err := url.Parse(addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse device address: %w", err)
+	}
+
+	dev := Device{outputDebug: debug}
+
+	switch u.Scheme {
+	case "serial":
+		dev.rawDevice, err = NewSerialDevice(u)
+	case "tcp":
+		dev.rawDevice, err = NewTCPDevice(u)
+	case "test":
+		dev.rawDevice, err = &MockDevice{}, nil
+	}
 
 	if err != nil {
 		return nil, err
 	}
-
-	dev := Device{rawDev, debug}
 
 	err = dev.SetAutomaticProtocol()
 
 	if err != nil {
 		return nil, err
 	}
-
-	return &dev, nil
-}
-
-// NewTestDevice constructs a Device which is using a mocked RawDevice.
-func NewTestDevice(devicePath string, debug bool) (*Device, error) {
-	dev := Device{&MockDevice{}, debug}
 
 	return &dev, nil
 }

--- a/examples/example_1/main.go
+++ b/examples/example_1/main.go
@@ -3,19 +3,25 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/rzetterberg/elmobd"
 )
 
 func main() {
-	serialPath := flag.String(
-		"serial",
-		"/dev/ttyUSB0",
-		"Path to the serial device to use",
+	addr := flag.String(
+		"addr",
+		"test:///dev/ttyUSB0",
+		"Address of the ELM327 device to use (use either test://, tcp://ip:port or serial:///dev/ttyS0)",
+	)
+	debug := flag.Bool(
+		"debug",
+		false,
+		"Enable debug outputs",
 	)
 
 	flag.Parse()
 
-	dev, err := elmobd.NewTestDevice(*serialPath, false)
+	dev, err := elmobd.NewDevice(*addr, *debug)
 
 	if err != nil {
 		fmt.Println("Failed to create new device", err)

--- a/examples/example_1/main.go
+++ b/examples/example_1/main.go
@@ -36,4 +36,12 @@ func main() {
 	}
 
 	fmt.Println("Device has version", version)
+
+	voltage, err := dev.GetVoltage()
+	if err != nil {
+		fmt.Println("Failed to get version", err)
+		return
+	}
+
+	fmt.Printf("Device has voltage %f V\n", voltage)
 }

--- a/examples/example_2/main.go
+++ b/examples/example_2/main.go
@@ -3,19 +3,25 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/rzetterberg/elmobd"
 )
 
 func main() {
-	serialPath := flag.String(
-		"serial",
-		"/dev/ttyUSB0",
-		"Path to the serial device to use",
+	addr := flag.String(
+		"addr",
+		"test:///dev/ttyUSB0",
+		"Address of the ELM327 device to use (use either test://, tcp://ip:port or serial:///dev/ttyS0)",
+	)
+	debug := flag.Bool(
+		"debug",
+		false,
+		"Enable debug outputs",
 	)
 
 	flag.Parse()
 
-	dev, err := elmobd.NewTestDevice(*serialPath, false)
+	dev, err := elmobd.NewDevice(*addr, *debug)
 
 	if err != nil {
 		fmt.Println("Failed to create new device", err)

--- a/examples/example_3/main.go
+++ b/examples/example_3/main.go
@@ -3,19 +3,25 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/rzetterberg/elmobd"
 )
 
 func main() {
-	serialPath := flag.String(
-		"serial",
-		"/dev/ttyUSB0",
-		"Path to the serial device to use",
+	addr := flag.String(
+		"addr",
+		"test:///dev/ttyUSB0",
+		"Address of the ELM327 device to use (use either test://, tcp://ip:port or serial:///dev/ttyS0)",
+	)
+	debug := flag.Bool(
+		"debug",
+		false,
+		"Enable debug outputs",
 	)
 
 	flag.Parse()
 
-	dev, err := elmobd.NewTestDevice(*serialPath, false)
+	dev, err := elmobd.NewDevice(*addr, *debug)
 
 	if err != nil {
 		fmt.Println("Failed to create new device", err)

--- a/examples/example_4/main.go
+++ b/examples/example_4/main.go
@@ -3,19 +3,25 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/rzetterberg/elmobd"
 )
 
 func main() {
-	serialPath := flag.String(
-		"serial",
-		"/dev/ttyUSB0",
-		"Path to the serial device to use",
+	addr := flag.String(
+		"addr",
+		"test:///dev/ttyUSB0",
+		"Address of the ELM327 device to use (use either test://, tcp://ip:port or serial:///dev/ttyS0)",
+	)
+	debug := flag.Bool(
+		"debug",
+		false,
+		"Enable debug outputs",
 	)
 
 	flag.Parse()
 
-	dev, err := elmobd.NewTestDevice(*serialPath, false)
+	dev, err := elmobd.NewDevice(*addr, *debug)
 
 	if err != nil {
 		fmt.Println("Failed to create new device", err)

--- a/examples/example_5/main.go
+++ b/examples/example_5/main.go
@@ -3,19 +3,25 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/rzetterberg/elmobd"
 )
 
 func main() {
-	serialPath := flag.String(
-		"serial",
-		"/dev/ttyUSB0",
-		"Path to the serial device to use",
+	addr := flag.String(
+		"addr",
+		"test:///dev/ttyUSB0",
+		"Address of the ELM327 device to use (use either test://, tcp://ip:port or serial:///dev/ttyS0)",
+	)
+	debug := flag.Bool(
+		"debug",
+		false,
+		"Enable debug outputs",
 	)
 
 	flag.Parse()
 
-	dev, err := elmobd.NewTestDevice(*serialPath, false)
+	dev, err := elmobd.NewDevice(*addr, *debug)
 
 	if err != nil {
 		fmt.Println("Failed to create new device", err)
@@ -29,7 +35,7 @@ func main() {
 		return
 	}
 
-        status := cmd.(*elmobd.MonitorStatus)
+	status := cmd.(*elmobd.MonitorStatus)
 
 	fmt.Printf("MIL is on: %t, DTCamount: %d\n", status.MilActive, status.DtcAmount)
 }

--- a/mockdevice.go
+++ b/mockdevice.go
@@ -136,6 +136,8 @@ func mockOutputs(cmd string) []string {
 		return []string{"OK"}
 	} else if cmd == "AT@1" {
 		return []string{"OBDII by elm329@gmail.com"}
+	} else if cmd == "AT RV" {
+		return []string{"12.1234"}
 	} else if strings.HasPrefix(cmd, "01") {
 		return mockMode1Outputs(cmd[2:])
 	}

--- a/realdevice.go
+++ b/realdevice.go
@@ -3,6 +3,10 @@ package elmobd
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -90,6 +94,22 @@ func NewSerialDevice(addr *url.URL) (*RealDevice, error) {
 		Size:        8,
 		Parity:      serial.ParityNone,
 		StopBits:    serial.Stop1,
+	}
+
+	q := addr.Query()
+	baudStr := q.Get("baudrate")
+	timeoutStr := q.Get("timeout")
+
+	if baudStr != "" {
+		if baud, err := strconv.Atoi(baudStr); err == nil {
+			config.Baud = baud
+		}
+	}
+
+	if timeoutStr != "" {
+		if to, err := time.ParseDuration(timeoutStr); err == nil {
+			config.ReadTimeout = to
+		}
 	}
 
 	port, err := serial.OpenPort(config)


### PR DESCRIPTION
# Description

This PR adds support for ELM327 devices connected via network sockets.
Currently, TCP and Unix Domain Sockets are supported.

Furthermore, this PR introduces a scheme for device URLs:

- Serial: `serial:///dev/ttyS0`
- TCP: `tcp://192.0.2.1:1234`
- Unix Sockets: `unix:/path/to/socket`


Last but not least, there is now a command for retrieving the voltage as read by the ELM327 chip via `Device.GetVoltage()`

This PR closes issue #34 

# Checklist

- [x] Running `go test` locally is successful
- [ ] **VERSION** has been changed
- [ ] Changes has been documented in **CHANGELOG.md**
