### PR TITLE
Fix typos

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -129,7 +129,7 @@ func (cmd *UIntCommand) ValueAsLit() string {
 // - Part 7 (0xC0): 0xC1 to 0xE0
 //
 // PID 0x00 checks which PIDs that are supported of part 1, after that, the
-// last PID of each part checks the supportedness of the next part.
+// last PID of each part checks the whether the next part is supported.
 //
 // So PID 0x20 of Part 1 checks which PIDs in part 2 are supported, PID 0x40 of
 // part 2 checks which PIDs in part 3 are supported, etc etc.
@@ -249,7 +249,7 @@ func (part *PartSupported) CommandInRange(cmd OBDCommand) bool {
 // but it fails for parts 2,3,4,5,6,7 and PIDs about 0x20.
 //
 // In order to make this work for other parts besides 1, we simply normalize the
-// PID number by removing 32 times the part index, instead of hardcoding the value
+// PID number by removing 32 times the part index, instead of hard coding the value
 // to subtract to 32.
 func (part *PartSupported) SupportsPID(comparePID OBDParameterID) bool {
 	if !part.PIDInRange(comparePID) {

--- a/device.go
+++ b/device.go
@@ -27,7 +27,7 @@ type Result struct {
 	value []byte
 }
 
-// NewResult constructrs a Result by taking care of parsing the hex bytes into
+// NewResult constructors a Result by taking care of parsing the hex bytes into
 // binary representation.
 func NewResult(rawLine string) (*Result, error) {
 	literals := strings.Split(rawLine, " ")
@@ -94,11 +94,11 @@ func (res *Result) Validate(cmd OBDCommand) error {
 	return nil
 }
 
-// payloadAsUInt casts the Result as a unisgned 64-bit integer and making sure
+// payloadAsUInt casts the Result as a unsigned 64-bit integer and making sure
 // it has the expected amount of bytes.
 //
 // This function is used by other more specific utility functions that cast the
-// result to a specific unsigned integer typer.
+// result to a specific unsigned integer type.
 //
 // By verifying the amount of bytes in the result using this function we can
 // safely cast the resulting uint64 into types with less bits.
@@ -191,7 +191,7 @@ type Device struct {
 	outputDebug bool
 }
 
-// NewDevice constructs a Device by initilizing the serial connection and
+// NewDevice constructs a Device by initializing the serial connection and
 // setting the protocol to talk with the car to "automatic".
 func NewDevice(devicePath string, debug bool) (*Device, error) {
 	rawDev, err := NewRealDevice(devicePath)
@@ -219,7 +219,7 @@ func NewTestDevice(devicePath string, debug bool) (*Device, error) {
 }
 
 // SetAutomaticProtocol tells the ELM327 device to automatically discover what
-// protocol to talk to the car with. How the protocol is chhosen is something
+// protocol to talk to the car with. How the protocol is chosen is something
 // that the ELM327 does internally. If you're interested in how this works you
 // can look in the data sheet linked in the beginning of the package description.
 func (dev *Device) SetAutomaticProtocol() error {
@@ -453,7 +453,7 @@ func (sc *SupportedCommands) FilterSupported(commands []OBDCommand) []OBDCommand
 // This means that this function cannot handle multiline responses
 // (such as getting the VIN number, and multiple PID requests baked into one).
 // Handling these more advanced responses is something that is going to be
-// implemented, but right now has been deprioritized.
+// implemented, but right now has been de-prioritized.
 func parseOBDResponse(cmd OBDCommand, outputs []string) (*Result, error) {
 	payload := ""
 

--- a/device_test.go
+++ b/device_test.go
@@ -184,8 +184,8 @@ func TestIsSupportedWikipediaExample(t *testing.T) {
 // each part has the first and last bit active, and all other bits inactive.
 //
 // This means that the first PID of the part should be supported, as well as
-// the last PID, which is the one you use to check the supportedness of PIDs of
-// the next part.
+// the last PID, which is the one you use to check which PIDs of
+// the next part are supported.
 //
 // Source: https://github.com/rzetterberg/elmobd/issues/27
 func TestIssue27Regression(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -30,7 +30,7 @@
 //
 // The Device type represents an active connection with an ELM327 device. You
 // plug in your device into your computer, get the path to the device and
-// initlize a new device:
+// initialize a new device:
 //
 //     package main
 //

--- a/realdevice.go
+++ b/realdevice.go
@@ -307,7 +307,7 @@ func (dev *RealDevice) processResult(result bytes.Buffer) error {
 	}
 
 	if len(trimmedParts) < 1 {
-		return fmt.Errorf("No payload receieved")
+		return fmt.Errorf("No payload received")
 	}
 
 	dev.outputs = trimmedParts


### PR DESCRIPTION
This PR fixes several typos in the Go code.
The PR only touches comments no real code.