### PR TITLE
Add function to retrieve battery voltage as seen by ELM327 chip

### DIFF
--- a/device.go
+++ b/device.go
@@ -264,6 +264,29 @@ func (dev *Device) GetVersion() (string, error) {
 	return strings.Trim(version, " "), nil
 }
 
+// GetVoltage gets the current battery voltage of the vehicle as measured
+// by the ELM327 device.
+func (dev *Device) GetVoltage() (float32, error) {
+	rawRes := dev.rawDevice.RunCommand("AT RV")
+
+	if rawRes.Failed() {
+		return -1, rawRes.GetError()
+	}
+
+	if dev.outputDebug {
+		fmt.Println(rawRes.FormatOverview())
+	}
+
+	output := rawRes.GetOutputs()[0]
+	voltage, err := strconv.ParseFloat(output[:len(output)-1], 32)
+
+	if err != nil {
+		return -1, fmt.Errorf("voltage is not a floating point number: %w", err)
+	}
+
+	return float32(voltage), nil
+}
+
 // CheckSupportedCommands check which commands are supported by the car connected
 // to the ELM327 device.
 func (dev *Device) CheckSupportedCommands() (*SupportedCommands, error) {


### PR DESCRIPTION
# Description

This PR adds a function which gets the current battery voltage as seen by the ELM327 chip

# Checklist

- [ ] Running `go test` locally is successful
- [ ] **VERSION** has been changed
- [ ] Changes has been documented in **CHANGELOG.md**
