### PR TITLE
PID 31 (time since engine start) returns 2 bytes, not 1

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -870,7 +870,7 @@ type RuntimeSinceStart struct {
 // parameters.
 func NewRuntimeSinceStart() *RuntimeSinceStart {
 	return &RuntimeSinceStart{
-		baseCommand{SERVICE_01_ID, 31, 1, "runtime_since_engine_start"},
+		baseCommand{SERVICE_01_ID, 31, 2, "runtime_since_engine_start"},
 		UIntCommand{},
 	}
 }


### PR DESCRIPTION
# Description

PID 31 (time since engine start) returns 2 bytes, not 1.

Verified on an Opel Vivaro B (2017).

See: https://en.wikipedia.org/wiki/OBD-II_PIDs

# Checklist

- [ ] Running `go test` locally is successful
- [ ] **VERSION** has been changed
- [ ] Changes has been documented in **CHANGELOG.md**
