### PR TITLE
Make CheckSupportedCommands more robust

### DIFF
--- a/device.go
+++ b/device.go
@@ -278,17 +278,17 @@ func (dev *Device) CheckSupportedCommands() (*SupportedCommands, error) {
 
 		partRes, err := dev.RunOBDCommand(part)
 
-		if err != nil {
-			return nil, err
+		if err == nil {
+			result.AddPart(partRes.(*PartSupported))
+
+			// Check if the car supports the PID that checks if the next part of PIDs
+			// are supported
+			if !part.SupportsNextPart() {
+				break
+			}
 		}
 
-		result.AddPart(partRes.(*PartSupported))
-
-		// Check if the car supports the PID that checks if the next part of PIDs
-		// are supported
-		if !part.SupportsNextPart() {
-			break
-		}
+		index++
 	}
 
 	return result, nil


### PR DESCRIPTION
# Description

I had some issues with the detection of supported PIDs on an Opel Vivaro B (2017) as it errored out in `CheckSupportedCommands()` returning an empty list of supported PIDs.

This change will abort checking parts after the first error, but still return the previously detected parts.

# Checklist

- [ ] Running `go test` locally is successful
- [ ] **VERSION** has been changed
- [ ] Changes has been documented in **CHANGELOG.md**
